### PR TITLE
Make generated setUp() declaration work with phpunit 9.2.6, php 7.4

### DIFF
--- a/templates/phpunit.twig
+++ b/templates/phpunit.twig
@@ -26,7 +26,7 @@ class {{ class }}Test extends {{ baseClass.class }}
     private ${{ dependency | transformDependency }};
 
 {% endfor %}
-    protected function setUp()
+    protected function setUp(): void
     {
 {% for dependency in dependencies %}
 {% if not dependency.value|isNull %}


### PR DESCRIPTION
This fixes an error that is thrown on startup using generated test cases:
```bash
Fatal error: Declaration of YourClassTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in [...] /tests/YourClassTest.php on line [...]
```